### PR TITLE
Fix rendering for empty arrays and empty objects

### DIFF
--- a/docs/App.svelte
+++ b/docs/App.svelte
@@ -25,12 +25,17 @@ const test1 = [
     longitude: -0.093647,
     tags: ['quis', 'officia', 'ullamco', 'occaecat', 'sint', 'pariatur', 'fugiat'],
     friends: [
-      { id: 0, name: 'Thelma Robles' },
-      { id: 1, name: 'Genevieve Russo' },
-      { id: 2, name: 'Mcclure Tate' }
+      { id: 0, name: 'Thelma Robles', address: [] },
+      { id: 1, name: 'Genevieve Russo', address: {} },
+      { id: 2, name: 'Mcclure Tate', address: null }
     ],
     greeting: 'Hello, Hampton Hardin! You have 2 unread messages.',
-    favoriteFruit: 'banana'
+    favoriteFruit: 'banana',
+    contacts: [],
+    report: {},
+    email2: null,
+    email3: '',
+    email4: undefined
   },
   {
     _id: '60702426f2aec6774924fd63',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zerodevx/svelte-json-view",
-  "version": "0.2.1",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerodevx/svelte-json-view",
-      "version": "0.2.1",
+      "version": "0.2.0",
       "license": "ISC",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^22.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zerodevx/svelte-json-view",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerodevx/svelte-json-view",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "ISC",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^22.0.0",

--- a/src/JsonView.svelte
+++ b/src/JsonView.svelte
@@ -41,7 +41,11 @@ const clicked = () => {
 }
 </script>
 
-{#if items.length}
+{#if !items.length}
+  <span class="bracket" tabindex="0">{openBracket}{closeBracket}</span>{#if !_last}<span
+      class="comma">,</span
+    >{/if}
+{:else}
   <span class:hidden={collapsed}>
     <span class="bracket" on:click={clicked} tabindex="0">{openBracket}</span>
     <ul>


### PR DESCRIPTION
At the moment empty arrays and objects are not rendered. This can cause errors, when copying the json and trying to use it somewhere else.

- added code to render valid brackets
- updated App.svelte test1 json to include empty object, array, string, null and undefined. Those were added to the top and the nth level of json.

current main:
<img width="655" alt="Screenshot 2022-09-09 at 10 54 46" src="https://user-images.githubusercontent.com/113172649/189324148-e4bb52dc-0255-4ae6-a5a9-faef0433a7c2.png">
fix branch:
<img width="596" alt="Screenshot 2022-09-09 at 11 02 06" src="https://user-images.githubusercontent.com/113172649/189325495-ba2c1ed4-f3c7-4a77-ab78-9e2a4f373813.png">

